### PR TITLE
Add transaction protos

### DIFF
--- a/protos/bond.proto
+++ b/protos/bond.proto
@@ -35,7 +35,8 @@ message Bond {
     // Identifier of the bond (ISIN).
     string bond_id = 1;
 
-    // Ticker symbol of the organization which issued the bond.
+    // Organization ID, either ticker symbol or pricing source,
+    //  of the firm which issued the bond.
     string issuing_organization_id = 2;
 
     // List of bond ratings by agency.

--- a/protos/order.proto
+++ b/protos/order.proto
@@ -41,7 +41,8 @@ message Order {
     // Whether this is a MARKET or LIMIT order.
     OrderType order_type = 3;
 
-    // Ticker symbol of the organization the order is on bahalf of.
+    // Ticker symbol or pricing source of the 
+    // organization the order is on behalf of.
     string ordering_organization_id = 4;
 
     // ISIN of the bond the order is for.

--- a/protos/organization.proto
+++ b/protos/organization.proto
@@ -27,7 +27,7 @@ message Organization {
             BOND = 1;
         }
 
-        // Whether the asset is CURRENCY or a BOND
+        // Whether the asset is CURRENCY or a BOND.
         AssetType asset_type = 1;
 
         // If asset_type is BOND, the asset_id will contain the bond_id. If
@@ -77,13 +77,19 @@ message Organization {
         uint64 timestamp = 5;
     }
 
-    // Ticker symbol associated with the organization.
+    // Ticker symbol is for organizations with organization type 'TRADING FIRM'
+    // uniquely identifying the organization.
+    // Pricing source is for organizations with organization type 'PRICING SOURCE'
+    // is a four-letter code representing organizations responsible for 
+    // providing quotes to the market.
+    // Ticker symbol or pricing source provided dependent on organization type.
     string organization_id = 1;
 
     // Name of the organization.
     string name = 2;
 
     // Type of the organization.
+    // Determines the format of the organization_id.
     OrganizationType organization_type = 3;
 
     // Industry of the organization.
@@ -92,15 +98,11 @@ message Organization {
     // List of the assets that the organization owns.
     repeated Holding holdings = 5;
 
-    // Four-letter code representing the identity of the organization for
-    // the purpose of providing quotes to the market.
-    string pricing_source = 6;
-
     // List of participant public keys and their roles within the organization.
-    repeated Authorization authorizations = 7;
+    repeated Authorization authorizations = 6;
 
     // List of coupon and redemption receipts.
-    repeated Receipt receipts = 8;
+    repeated Receipt receipts = 7;
 }
 
 message OrganizationContainer {

--- a/protos/participant.proto
+++ b/protos/participant.proto
@@ -22,7 +22,8 @@ message Participant {
     // Username of the participant.
     string username = 2;
 
-    // Ticker symbol of the participant's organization.
+    // Ticker symbol or pricing source of the participant's 
+    // organization.
     string organization_id = 3;
 }
 

--- a/protos/payload.proto
+++ b/protos/payload.proto
@@ -1,0 +1,46 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message BondPayload{
+    enum Action {
+        CREATE_ORGANIZATION = 0;
+        UPDATE_ORGANIZATION = 1;
+        UPDATE_ORGANIZATION_AUTHORIZATION = 2;
+
+        CREATE_PARTICIPANT = 3;
+        UPDATE_PARTICIPANT = 4;
+
+        CREATE_ORDER = 5;
+
+        CREATE_QUOTE = 6;
+
+        CREATE_SETTLEMENT = 7;
+
+        CREATE_RECEIPT = 8;
+
+        CREATE_HOLDING = 9;
+        DELETE_HOLDING = 10;
+
+        CREATE_BOND = 11;
+    }
+
+    // Type of transaction data the payload contains
+    Action action = 1;
+
+    // Payload data
+    bytes content = 2;
+}

--- a/protos/payload_bond.proto
+++ b/protos/payload_bond.proto
@@ -1,0 +1,58 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "bond.proto";
+
+message CreateBond {
+
+    // Identifier of the bond (ISIN).
+    string bond_id = 1;
+
+    // List of bond ratings by agency.
+    repeated Bond.CorporateDebtRating corporate_debt_ratings = 2;
+
+    // The yearly rate of interest paid in coupons.
+    // Format: Thousandths of percents
+    uint64 coupon_rate = 3;
+
+    // If floating, the interest rate is calculated by adding coupon-rate
+    // to the rate looked up using the benchmark index (Libor).
+    Bond.CouponType coupon_type = 4;
+
+    // How often the coupons are paid out.
+    Bond.CouponFrequency coupon_frequency = 5;
+
+    // The date the first coupon can be paid for the bond.
+    // Format: UTC Timestamp
+    uint64 first_coupon_date = 6;
+
+    // The date on which the bond becomes worth it's face value
+    //  and can be redeemed.
+    // Format: UTC Timestamp
+    uint64 maturity_date = 7;
+
+    // Quantity of bonds.
+    uint64 amount_outstanding = 8;
+
+    // The par-value of the bond, to be paid upon maturity.
+    // Format: Millionths of dollars
+    uint64 face_value = 9;
+
+    // Date on which the bond was first settled.
+    // Format: UTC Timestamp
+    uint64 first_settlement_date = 10;
+}

--- a/protos/payload_holding.proto
+++ b/protos/payload_holding.proto
@@ -1,0 +1,38 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "organization.proto";
+
+message CreateHolding {
+
+    // Whether the asset is currency or a bond.
+    Organization.Holding.AssetType asset_type = 1;
+
+    // If asset_type is BOND, the asset-id will contain the bond_id.
+    // For asset_type of CURRENCY, this will be the string 'USD'.
+    string asset_id = 2;
+
+    // The current balance.
+    uint64 amount = 3;
+}
+
+message DeleteHolding {
+
+    // If asset_type is BOND, the asset-id will contain the bond_id.
+    // For asset_type of CURRENCY, this will be the string 'USD'.
+    string asset_id = 1;
+}

--- a/protos/payload_order.proto
+++ b/protos/payload_order.proto
@@ -1,0 +1,49 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "order.proto";
+
+message CreateOrder {
+
+    // Determines a buy or sell order.
+    Order.Action action = 1;
+
+    // Determines a limit or market order. 
+    Order.OrderType order_type = 2;
+
+    // ID of the bond the order is for
+    string bond_id = 3;
+
+    // The maximum price the ordering firm is willing to pay for a bond or
+    // the minimum price they are willing to sell, depending on order_type.
+    // If order_type is "MARKET", this field should not be set.
+    // If order_type is "LIMIT", limit-price or limit-yield must be set.
+    // Format: Millionths of dollars
+    uint64 limit_price = 4;
+
+    // The minimum yield at which the ordering firm is willing to buy a
+    // bond or the maximum yield at which they are willing to sell.
+    // If order-type is "MARKET", this field should not be set.
+    // if order-type is "LIMIT", limit-price or limit-yield must be set.
+    // Format: Thousandths of percents
+    uint64 limit_yield = 5;
+
+    // The quantity the firm wishes to buy or sell in USD as a multiple of
+    // the bond's par value.
+    // Format: Millionths of dollars
+    uint64 quantity = 6;
+}

--- a/protos/payload_organization.proto
+++ b/protos/payload_organization.proto
@@ -1,0 +1,71 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "organization.proto";
+
+message CreateOrganization {
+
+    // The name of the organization
+    string name = 1;
+
+    // Type of the organization.
+    Organization.OrganizationType organization_type = 2;
+
+    // The industry of the organization.
+    string industry = 3;
+
+    // Ticker symbol is for organizations with organization type 'TRADING FIRM'
+    // uniquely identifying the organization.
+    // Pricing source is for organizations with organization type 'PRICING SOURCE'
+    // is a four-letter code representing organizations responsible for
+    // providing quotes to the market.
+    // Ticker symbol or pricing source provided dependent on organization type.
+    string organization_id = 4;
+
+    // List of participant public keys and their roles
+    // within the organization.
+    repeated Organization.Authorization authorizations = 5;
+}
+
+message UpdateOrganization {
+
+    // The name of the organization.
+    string name = 1;
+
+    // The industry of the organization.
+    string industry = 4;
+}
+
+message UpdateOrganizationAuthorization {
+
+    enum AuthorizationAction {
+        ADD = 0;
+        REMOVE = 1;
+    }
+
+    // If set to ADD, then this is a request to add an entry to the list.
+    // If set to REMOVE, this is a request to remove an entry.
+    AuthorizationAction authorization_action = 1;
+
+    // Public key of the participant whose authorization is being altered.
+    string public_key = 2;
+
+    // Role to update the specified participant entry.
+    // Roles grant permissions for a participant to act on behalf of the 
+    // Organization in some capacity.
+    Organization.Authorization.Role role = 3;
+}

--- a/protos/payload_participant.proto
+++ b/protos/payload_participant.proto
@@ -1,0 +1,40 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message CreateParticipant {
+    
+    // The public key associated with the participant used to sign
+    // transactions.
+    string public_key = 1;
+
+    // Username of the participant.
+    string username = 2;
+
+    // The ticker symbol or pricing source of the participant's 
+    // organization.
+    string organization_id = 3;
+}
+
+message UpdateParticipant {
+
+    // Username of the participant.
+    string username = 1;
+
+    // The ticker symbol or pricing source of the participant's 
+    // organization.
+    string organization_id = 2;
+}

--- a/protos/payload_quote.proto
+++ b/protos/payload_quote.proto
@@ -1,0 +1,36 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message CreateQuote {
+
+    // ID of the bond the quote is for.
+    string bond_id = 1;
+
+    // The minimum price for which the firm is willing to sell the bond.
+    // Format: Millionths of dollars
+    uint64 ask_price = 2;
+
+    // The maximum quantity the firm is willing to sell.
+    uint64 ask_qty = 3;
+
+    // The maximum price for which the firm is willing to sell the bond.
+    // Format: Millionths of dollars
+    uint64 bid_price = 4;
+
+    // The minimum quantity the firm is willing to sell.
+    uint64 bid_qty = 5;
+}

--- a/protos/payload_quote.proto
+++ b/protos/payload_quote.proto
@@ -27,10 +27,10 @@ message CreateQuote {
     // The maximum quantity the firm is willing to sell.
     uint64 ask_qty = 3;
 
-    // The maximum price for which the firm is willing to sell the bond.
+    // The maximum price for which the firm is willing to buy the bond.
     // Format: Millionths of dollars
     uint64 bid_price = 4;
 
-    // The minimum quantity the firm is willing to sell.
+    // The minimum quantity the firm is willing to buy.
     uint64 bid_qty = 5;
 }

--- a/protos/payload_receipt.proto
+++ b/protos/payload_receipt.proto
@@ -1,0 +1,36 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "organization.proto";
+
+message CreateReceipt {
+
+    // Whether it was a coupon or redemption payment.
+    Organization.Receipt.PaymentType payment_type = 1;
+
+    // The ID of the bond for which this payment occurred.
+    string bond_id = 2;
+
+    // The date that the coupon became due.
+    // Required if payment-type is COUPON.
+    // Format: UTC Timestamp
+    uint64 coupon_date = 3;
+
+    // Amount received.
+    // Format: Millionths of dollars
+    uint64 amount = 4;
+}

--- a/protos/payload_settlement.proto
+++ b/protos/payload_settlement.proto
@@ -1,0 +1,22 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message CreateSettlement {
+
+    // The ID of the order which is being settled.
+    string order_id = 1;
+}

--- a/protos/quote.proto
+++ b/protos/quote.proto
@@ -38,11 +38,11 @@ message Quote {
     // Maximum quantity the firm is willing to sell.
     uint64 ask_qty = 5;
 
-    // Maximum price for which the firm is willing to sell the bond.
+    // Maximum price for which the firm is willing to buy the bond.
     // Format: Millionths of dollars
     uint64 bid_price = 6;
 
-    // Minimum quantity the firm is willing to sell.
+    // Maximum quantity the firm is willing to buy.
     uint64 bid_qty = 7;
 
     // Whether the quote is OPEN or CLOSED. Quotes are OPEN if they have

--- a/protos/quote.proto
+++ b/protos/quote.proto
@@ -24,7 +24,8 @@ message Quote {
     // UUID of the quote.
     string quote_id = 1;
 
-    // Ticker symbol of the organization the quote is on bahalf of.
+    // Ticker symbol or pricing source of the 
+    // organization the quote is on behalf of.
     string organization = 2;
 
     // ID of the bond the quote is for.
@@ -52,7 +53,7 @@ message Quote {
     // associated with the quote.
     Status status = 8;
 
-    // Time that the quote is created in relation to the current clock
+    // Time that the quote is created in relation to the current clock.
     // Format: UTC Timestamp
     uint64 timestamp = 9;
 }

--- a/protos/settlement.proto
+++ b/protos/settlement.proto
@@ -24,10 +24,12 @@ message Settlement {
     // ID of the order which is being settled.
     string order_id = 1;
 
-    // Ticker symbol of the organization on whose behalf the order was entered.
+    // Ticker symbol or pricing source of the organization on 
+    // whose behalf the order was entered.
     string ordering_organization_id = 2;
 
-    // Ticker symbol of the organization that supplied the quote matched with the order.
+    // Ticker symbol or pricing source of the organization that 
+    // supplied the quote matched with the order.
     string quoting_organization_id = 3;
 
     // Buy or sell settlement from the perspective of the ordering organization.


### PR DESCRIPTION
Creates the bond transaction protos based on the current state objects.

Signed-off-by: Shannyn Telander <telander@bitwise.io>