### PR TITLE
Initialize Bond REST API

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,26 @@ services:
         cargo build
       "
 
+  bond-rest-api:
+    image: bond-rest-api
+    container_name: bond-rest-api
+    build:
+      context: .
+      dockerfile: ./rest_api/Dockerfile
+    volumes:
+      - '.:/project/sawtooth-bond'
+    ports:
+      - '8000:8000'
+    environment:
+      ROCKET_ADDRESS: "0.0.0.0"
+      ROCKET_PORT: "8000"
+    command: |
+      bash -c "
+        cd rest_api
+        cargo build
+        bond-rest-api
+      "
+
   postgres:
     image: postgres:alpine
     container_name: bond-postgres

--- a/rest_api/Cargo.toml
+++ b/rest_api/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright 2018 Bitwise IO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "bond-rest-api"
+version = "0.1.0"
+authors = ["Bitwise IO"]
+
+[dependencies]
+rocket = "0.3.15"
+rocket_codegen = "0.3.15"
+rocket_contrib = "0.3.15"
+serde_json = "1.0"

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2018 Bitwise IO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+FROM rust:latest
+
+RUN rustup default nightly
+
+RUN export CARGO_INCREMENTAL=1
+
+RUN apt-get update && apt-get install -y unzip
+
+# For Building Protobufs
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+ && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
+ && rm protoc-3.5.1-linux-x86_64.zip
+RUN apt-get update && apt-get install -y protobuf-compiler
+
+WORKDIR /project/sawtooth-bond
+
+ENV PATH=$PATH:/project/sawtooth-bond/rest_api/target/debug/

--- a/rest_api/src/errors.rs
+++ b/rest_api/src/errors.rs
@@ -1,0 +1,56 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocket::http::ContentType;
+use rocket::http::Status;
+use rocket::request::Request;
+use rocket::response::{Responder, Response};
+use rocket_contrib::{Json, Value};
+use std::io::Cursor;
+
+#[catch(404)]
+pub fn not_found() -> Json<Value> {
+    Json(json!({
+        "error": {
+            "status": 404,
+            "message": "Not found"
+        }
+    }))
+}
+
+#[derive(Debug)]
+pub enum ApiError {
+    /// Defines the HTTP Errors that the API can return.
+    NotImplemented,
+}
+
+impl<'r> Responder<'r> for ApiError {
+    /// JSON responder for ApiErrors.
+    fn respond_to(self, _req: &Request) -> Result<Response<'r>, Status> {
+        match self {
+            ApiError::NotImplemented => Response::build()
+                .header(ContentType::JSON)
+                .status(Status::NotImplemented)
+                .sized_body(Cursor::new(
+                    json!({
+                        "error": {
+                            "status": 501,
+                            "message": "Not implemented",
+                        }
+                    }).to_string(),
+                ))
+                .ok(),
+        }
+    }
+}

--- a/rest_api/src/main.rs
+++ b/rest_api/src/main.rs
@@ -1,0 +1,62 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// 'print_literal' lint disabled due to an issue in Rocket
+// https://github.com/SergioBenitez/Rocket/issues/698
+#![cfg_attr(feature = "cargo-clippy", allow(print_literal))]
+#![feature(plugin)]
+#![plugin(rocket_codegen)]
+
+extern crate rocket;
+#[macro_use]
+extern crate rocket_contrib;
+
+mod errors;
+mod route_handlers;
+
+use route_handlers::{bonds, holdings, orders, organizations, participants, quotes, settlements};
+
+fn main() {
+    rocket::ignite()
+        .catch(catchers![errors::not_found])
+        .mount(
+            "/",
+            routes![
+                bonds::create_bond,
+                bonds::list_bonds,
+                bonds::retrieve_bond,
+                holdings::create_holding,
+                holdings::delete_holding,
+                participants::login,
+                organizations::create_organization,
+                organizations::list_organizations,
+                organizations::update_organization,
+                organizations::retrieve_organization,
+                organizations::update_organization_auth,
+                participants::create_participant,
+                participants::list_participants,
+                participants::update_participant,
+                participants::retrieve_participant,
+                quotes::create_quote,
+                quotes::list_quotes,
+                quotes::retrieve_quote,
+                orders::create_order,
+                orders::list_orders,
+                orders::retrieve_order,
+                settlements::create_settlement,
+                settlements::list_settlements
+            ],
+        )
+        .launch();
+}

--- a/rest_api/src/route_handlers/bonds.rs
+++ b/rest_api/src/route_handlers/bonds.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::ApiError;
+use rocket::http::RawStr;
+use rocket_contrib::{Json, Value};
+
+#[post("/bonds")]
+pub fn create_bond() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/bonds")]
+pub fn list_bonds() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/bonds/<_bond_id>")]
+pub fn retrieve_bond(_bond_id: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}

--- a/rest_api/src/route_handlers/holdings.rs
+++ b/rest_api/src/route_handlers/holdings.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::ApiError;
+use rocket::http::RawStr;
+use rocket_contrib::{Json, Value};
+
+#[post("/holdings")]
+pub fn create_holding() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[delete("/holdings/<_asset_id>")]
+pub fn delete_holding(_asset_id: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}

--- a/rest_api/src/route_handlers/mod.rs
+++ b/rest_api/src/route_handlers/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod bonds;
+pub mod holdings;
+pub mod orders;
+pub mod organizations;
+pub mod participants;
+pub mod quotes;
+pub mod settlements;

--- a/rest_api/src/route_handlers/orders.rs
+++ b/rest_api/src/route_handlers/orders.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::ApiError;
+use rocket::http::RawStr;
+use rocket_contrib::{Json, Value};
+
+#[post("/orders")]
+pub fn create_order() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/orders")]
+pub fn list_orders() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/orders/<_order_id>")]
+pub fn retrieve_order(_order_id: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}

--- a/rest_api/src/route_handlers/organizations.rs
+++ b/rest_api/src/route_handlers/organizations.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::ApiError;
+use rocket::http::RawStr;
+use rocket_contrib::{Json, Value};
+
+#[post("/organizations")]
+pub fn create_organization() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/organizations")]
+pub fn list_organizations() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[post("/organizations/<_organization_id>")]
+pub fn update_organization(_organization_id: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/organizations/<_organization_id>")]
+pub fn retrieve_organization(_organization_id: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[post("/organizations/<_organization_id>/auth")]
+pub fn update_organization_auth(_organization_id: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}

--- a/rest_api/src/route_handlers/participants.rs
+++ b/rest_api/src/route_handlers/participants.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::ApiError;
+use rocket::http::RawStr;
+use rocket_contrib::{Json, Value};
+
+#[post("/login")]
+pub fn login() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[post("/participants")]
+pub fn create_participant() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/participants")]
+pub fn list_participants() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[post("/participants/<_public_key>")]
+pub fn update_participant(_public_key: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/participants/<_public_key>")]
+pub fn retrieve_participant(_public_key: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}

--- a/rest_api/src/route_handlers/quotes.rs
+++ b/rest_api/src/route_handlers/quotes.rs
@@ -1,0 +1,32 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::ApiError;
+use rocket::http::RawStr;
+use rocket_contrib::{Json, Value};
+
+#[post("/quotes")]
+pub fn create_quote() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/quotes")]
+pub fn list_quotes() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/quotes/<_quote_id>")]
+pub fn retrieve_quote(_quote_id: &RawStr) -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}

--- a/rest_api/src/route_handlers/settlements.rs
+++ b/rest_api/src/route_handlers/settlements.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::ApiError;
+use rocket_contrib::{Json, Value};
+
+#[post("/settlements")]
+pub fn create_settlement() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}
+
+#[get("/settlements")]
+pub fn list_settlements() -> Result<Json<Value>, ApiError> {
+    Err(ApiError::NotImplemented)
+}


### PR DESCRIPTION
- Implements the skeleton of the Bond REST API. All valid routes will return a 501, and everything else returns a 404.


- Adds a REST API Dockerfile (installs nightly Rust as required by Rocket), and deploys it using the docker-compose file.

REST API is accessible at localhost:8000 