### PR TITLE
Create Bond CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright 2018 Bitwise IO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "bond-cli"
+version = "0.1.0"
+authors = ["Bitwise IO"]
+
+[dependencies]
+clap = {version = "2", features = ["yaml"]}
+dirs = "1.0"
+log = "0.3.8"
+serde = "1.0"
+serde_derive = "1.0"
+simple_logger = "0.4.0"
+toml = "0.4"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2018 Bitwise IO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+FROM rust:latest
+
+RUN export CARGO_INCREMENTAL=1
+
+WORKDIR /project/sawtooth-bond
+
+ENV PATH=$PATH:/project/sawtooth-bond/cli/target/debug/

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgMatches;
+use clap::Error;
+use config;
+
+pub fn run<'a>(args: &ArgMatches<'a>) -> Result<(), Error> {
+    let rest_api_url = args.value_of("url").unwrap();
+    config::set_config(rest_api_url)?;
+    info!(
+        "Initializing Bond CLI to communicate with {}",
+        &rest_api_url
+    );
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod init;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,61 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use dirs;
+use std::fs;
+use std::io;
+use std::io::prelude::*;
+use std::path::PathBuf;
+use toml;
+
+#[derive(Serialize, Deserialize)]
+struct Config {
+    rest_api_url: String,
+}
+
+fn get_data_dir() -> PathBuf {
+    let mut path = dirs::home_dir().unwrap();
+    path.push(".sawtooth");
+    path
+}
+
+fn get_config_file() -> PathBuf {
+    let mut path = get_data_dir();
+    path.push("bond-config.toml");
+    path
+}
+
+fn create_config_file() -> Result<(), io::Error> {
+    if !&get_data_dir().exists() {
+        fs::create_dir(&get_data_dir())?;
+    }
+    fs::File::create(&get_config_file())?;
+    Ok(())
+}
+
+pub fn set_config(url: &str) -> Result<(), io::Error> {
+    let config = Config {
+        rest_api_url: url.to_string(),
+    };
+    let toml = toml::to_string(&config).expect("Unable to set config");
+
+    let config_file = get_config_file();
+    if !config_file.exists() {
+        create_config_file()?;
+    }
+    let mut f = fs::File::create(config_file)?;
+
+    f.write_all(toml.as_bytes())?;
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,71 @@
+// Copyright 2018 Bitwise IO
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate serde_derive;
+extern crate dirs;
+extern crate simple_logger;
+extern crate toml;
+#[macro_use]
+extern crate log;
+
+mod commands;
+mod config;
+
+use clap::ArgMatches;
+use commands::init;
+use log::LogLevel;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    let args = parse_args();
+
+    let logger = match args.occurrences_of("verbose") {
+        1 => simple_logger::init_with_level(LogLevel::Info),
+        2 => simple_logger::init_with_level(LogLevel::Debug),
+        0 | _ => simple_logger::init_with_level(LogLevel::Warn),
+    };
+    logger.expect("Logger was not created");
+
+    let result = match args.subcommand() {
+        ("init", Some(args)) => init::run(args),
+        _ => unreachable!(),
+    };
+
+    std::process::exit(match result {
+        Ok(_) => 0,
+        Err(err) => {
+            eprintln!("{}", err);
+            1
+        }
+    });
+}
+
+fn parse_args<'a>() -> ArgMatches<'a> {
+    let args = clap_app!(bond_cli =>
+        (name: "bond-cli")
+        (version: VERSION)
+        (author: "Bitwise IO")
+        (about: "Command-line interface for the Sawtooth Bond application")
+        (@setting SubcommandRequiredElseHelp)
+        (@arg verbose: -v... "Sets the logging verbosity level")
+        (@subcommand init =>
+            (about: "Sets the URL of the Bond REST API")
+            (@arg url: --url +takes_value +required "URL of the Bond REST API"))
+    );
+    args.get_matches()
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,22 @@ version: '2.1'
 
 services:
 
+  bond-cli:
+    image: bond-cli
+    container_name: bond-cli
+    build:
+      context: .
+      dockerfile: ./cli/Dockerfile
+    volumes:
+      - '.:/project/sawtooth-bond'
+    command: |
+      bash -c "
+        cd cli
+        cargo build
+        bond-cli init --url bond-rest-api:8000
+        tail -f /dev/null
+      "
+
   bond-processor:
     image: bond-processor
     container_name: bond-processor


### PR DESCRIPTION
This PR creates a CLI app for Bond. This app will be extended to allow transactions to be submitted to the Bond REST API.

This PR implements one command, `bond-cli init --url <url>`, which takes a URL and stores it in a config file. This will file will be read by other commands when submitting transactions.